### PR TITLE
Add hackney to extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule LoggerHumioBackend.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :hackney]
     ]
   end
 


### PR DESCRIPTION
This avoids a race condition when the application is starting. It doesn't always happen but I was able to replicate the issue @darkua mentioned while running locally. Adding `hackney` to the `extra_applications` seems to have solved the problem (tested my fork locally).

```
Compiling 1 file (.ex)
2020-10-06 13:31:34.258 [info] [alarm_handler: {:set, {{:disk_almost_full, '/System/Volumes/Data'}, []}}]
2020-10-06 13:31:34.267 [info] [alarm_handler: {:set, {:system_memory_high_watermark, []}}]
2020-10-06 13:31:34.470 mfa=:gen_event.report_error/5 file=gen_event.erl line=747 [error] :gen_event handler {Logger.Backend.Humio, :humio_logs} installed in Logger terminating
** (ArgumentError) argument error
    (stdlib 3.12.1) :ets.lookup_element(:hackney_config, :mod_metrics, 2)
    /Users/carlosbritolage/BlockFi/groot/deps/hackney/src/hackney_metrics.erl:26: :hackney_metrics.get_engine/0
    /Users/carlosbritolage/BlockFi/groot/deps/hackney/src/hackney_connect.erl:75: :hackney_connect.create_connection/5
    /Users/carlosbritolage/BlockFi/groot/deps/hackney/src/hackney_connect.erl:44: :hackney_connect.connect/5
    /Users/carlosbritolage/BlockFi/groot/deps/hackney/src/hackney.erl:333: :hackney.request/5
    lib/tesla/adapter/hackney.ex:71: Tesla.Adapter.Hackney.request/5
    lib/tesla/adapter/hackney.ex:33: Tesla.Adapter.Hackney.call/2
    lib/tesla/middleware/compression.ex:28: Tesla.Middleware.Compression.call/3
    lib/client/tesla_client.ex:10: Logger.Backend.Humio.Client.Tesla.send/1
    lib/ingest_api/unstructured.ex:17: Logger.Backend.Humio.IngestApi.Unstructured.transmit/1
    lib/logger_humio_backend.ex:29: Logger.Backend.Humio.handle_event/2
    (stdlib 3.12.1) gen_event.erl:577: :gen_event.server_update/4
    (stdlib 3.12.1) gen_event.erl:559: :gen_event.server_notify/4
    (stdlib 3.12.1) gen_event.erl:300: :gen_event.handle_msg/6
    (stdlib 3.12.1) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```