### PR TITLE
escape double quote from metadata string

### DIFF
--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -171,7 +171,7 @@ defmodule Logger.Backend.Humio.Formatter do
   defp metadata(:report_cb, _), do: nil
 
   defp metadata(_, nil), do: nil
-  defp metadata(_, string) when is_binary(string), do: string
+  defp metadata(_, string) when is_binary(string), do: "\"#{String.replace(string, "\"", "'")}\""
   defp metadata(_, integer) when is_integer(integer), do: Integer.to_string(integer)
   defp metadata(_, float) when is_float(float), do: Float.to_string(float)
   defp metadata(_, pid) when is_pid(pid), do: :erlang.pid_to_list(pid)


### PR DESCRIPTION
Hey @akasprzok so i noticed that adding structures as metadata would break key=value parser. I'm not sure if this is a 100% solution, but delimiting value with double quotes and replacing any occurrence with single quote, kind of works good with humio kv parser. What you think?